### PR TITLE
feat: make broker_heartbeat configurable via config.yaml

### DIFF
--- a/slidetap-app/src/slidetap/config.py
+++ b/slidetap-app/src/slidetap/config.py
@@ -120,6 +120,7 @@ class CeleryConfig:
     worker_max_memory_per_child: Optional[int] = None
     blocking: bool = False
     stuck_processing_threshold_seconds: int = 3600
+    broker_heartbeat: Optional[int] = 120
 
     @classmethod
     def parse(cls, parser: ConfigParser) -> "CeleryConfig":
@@ -134,6 +135,7 @@ class CeleryConfig:
         stuck_processing_threshold_seconds = parser.get_yaml_or_default(
             "stuck_processing_threshold_seconds", 3600
         )
+        broker_heartbeat = parser.get_yaml_or_default("broker_heartbeat", 120)
         return cls(
             broker_url,
             concurrency,
@@ -141,6 +143,7 @@ class CeleryConfig:
             max_memory_per_child,
             blocking,
             stuck_processing_threshold_seconds,
+            broker_heartbeat,
         )
 
     @property
@@ -153,7 +156,7 @@ class CeleryConfig:
             "worker_max_memory_per_child": self.worker_max_memory_per_child,
             "task_ignore_result": True,
             "broker_connection_retry_on_startup": True,
-            "broker_heartbeat": 120,
+            "broker_heartbeat": self.broker_heartbeat,
             "worker_prefetch_multiplier": 1,
             "task_always_eager": self.blocking,
             "task_eager_propagates": self.blocking,

--- a/slidetap-app/tests/test_celery_config.py
+++ b/slidetap-app/tests/test_celery_config.py
@@ -1,0 +1,62 @@
+#    Copyright 2024 SECTRA AB
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import pytest
+from slidetap.config import CeleryConfig, ConfigParser
+
+
+def make_parser(config: dict, broker_url: str = "amqp://localhost") -> ConfigParser:
+    """Helper to create a ConfigParser with an injected broker URL."""
+    parser = ConfigParser(config=config)
+    # Patch get_env so tests don't require environment variables
+    parser.get_env = lambda key, default=None: broker_url if key == "SLIDETAP_BROKER_URL" else default  # type: ignore[method-assign]
+    return parser
+
+
+@pytest.mark.unittest
+class TestCeleryConfigBrokerHeartbeat:
+    def test_default_heartbeat_when_no_celery_section(self):
+        # No 'celery' key in config → CeleryConfig uses field default (120)
+        parser = make_parser({})
+        config = CeleryConfig.parse(parser)
+        assert config.broker_heartbeat == 120
+
+    def test_default_heartbeat_when_celery_section_omits_key(self):
+        # 'celery' section exists but omits broker_heartbeat → default 120
+        parser = make_parser({"celery": {"concurrency": 2}})
+        config = CeleryConfig.parse(parser)
+        assert config.broker_heartbeat == 120
+
+    def test_custom_heartbeat_value(self):
+        # Explicit value in config is used
+        parser = make_parser({"celery": {"broker_heartbeat": 60}})
+        config = CeleryConfig.parse(parser)
+        assert config.broker_heartbeat == 60
+
+    def test_heartbeat_zero_disables_heartbeat(self):
+        # 0 is a valid value (disables heartbeat in Celery/AMQP)
+        parser = make_parser({"celery": {"broker_heartbeat": 0}})
+        config = CeleryConfig.parse(parser)
+        assert config.broker_heartbeat == 0
+
+    def test_heartbeat_propagates_to_dict_config(self):
+        # The value is passed through to the Celery dict config
+        parser = make_parser({"celery": {"broker_heartbeat": 30}})
+        config = CeleryConfig.parse(parser)
+        assert config.dict_config["broker_heartbeat"] == 30
+
+    def test_default_heartbeat_propagates_to_dict_config(self):
+        parser = make_parser({})
+        config = CeleryConfig.parse(parser)
+        assert config.dict_config["broker_heartbeat"] == 120

--- a/slidetap-app/tests/test_celery_config.py
+++ b/slidetap-app/tests/test_celery_config.py
@@ -12,51 +12,89 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from typing import Any, Dict
+
 import pytest
 from slidetap.config import CeleryConfig, ConfigParser
 
 
-def make_parser(config: dict, broker_url: str = "amqp://localhost") -> ConfigParser:
-    """Helper to create a ConfigParser with an injected broker URL."""
-    parser = ConfigParser(config=config)
-    # Patch get_env so tests don't require environment variables
+@pytest.fixture()
+def broker_url() -> str:
+    return "amqp://localhost"
+
+
+@pytest.fixture()
+def empty_config(broker_url: str) -> ConfigParser:
+    parser = ConfigParser(config={})
     parser.get_env = lambda key, default=None: broker_url if key == "SLIDETAP_BROKER_URL" else default  # type: ignore[method-assign]
     return parser
 
 
+@pytest.fixture()
+def config_with_celery(broker_url: str) -> ConfigParser:
+    def _make(celery_config: Dict[str, Any]) -> ConfigParser:
+        parser = ConfigParser(config={"celery": celery_config})
+        parser.get_env = lambda key, default=None: broker_url if key == "SLIDETAP_BROKER_URL" else default  # type: ignore[method-assign]
+        return parser
+    return _make  # type: ignore[return-value]
+
+
 @pytest.mark.unittest
-class TestCeleryConfigBrokerHeartbeat:
-    def test_default_heartbeat_when_no_celery_section(self):
-        # No 'celery' key in config → CeleryConfig uses field default (120)
-        parser = make_parser({})
-        config = CeleryConfig.parse(parser)
+class TestCeleryConfig:
+    def test_default_heartbeat_when_no_celery_section(self, empty_config: ConfigParser):
+        # Arrange
+
+        # Act
+        config = CeleryConfig.parse(empty_config)
+
+        # Assert
         assert config.broker_heartbeat == 120
 
-    def test_default_heartbeat_when_celery_section_omits_key(self):
-        # 'celery' section exists but omits broker_heartbeat → default 120
-        parser = make_parser({"celery": {"concurrency": 2}})
+    def test_default_heartbeat_when_celery_section_omits_key(self, config_with_celery):
+        # Arrange
+        parser = config_with_celery({"concurrency": 2})
+
+        # Act
         config = CeleryConfig.parse(parser)
+
+        # Assert
         assert config.broker_heartbeat == 120
 
-    def test_custom_heartbeat_value(self):
-        # Explicit value in config is used
-        parser = make_parser({"celery": {"broker_heartbeat": 60}})
+    def test_custom_heartbeat_value(self, config_with_celery):
+        # Arrange
+        parser = config_with_celery({"broker_heartbeat": 60})
+
+        # Act
         config = CeleryConfig.parse(parser)
+
+        # Assert
         assert config.broker_heartbeat == 60
 
-    def test_heartbeat_zero_disables_heartbeat(self):
-        # 0 is a valid value (disables heartbeat in Celery/AMQP)
-        parser = make_parser({"celery": {"broker_heartbeat": 0}})
+    def test_heartbeat_zero_disables_heartbeat(self, config_with_celery):
+        # Arrange
+        parser = config_with_celery({"broker_heartbeat": 0})
+
+        # Act
         config = CeleryConfig.parse(parser)
+
+        # Assert
         assert config.broker_heartbeat == 0
 
-    def test_heartbeat_propagates_to_dict_config(self):
-        # The value is passed through to the Celery dict config
-        parser = make_parser({"celery": {"broker_heartbeat": 30}})
+    def test_heartbeat_propagates_to_dict_config(self, config_with_celery):
+        # Arrange
+        parser = config_with_celery({"broker_heartbeat": 30})
+
+        # Act
         config = CeleryConfig.parse(parser)
+
+        # Assert
         assert config.dict_config["broker_heartbeat"] == 30
 
-    def test_default_heartbeat_propagates_to_dict_config(self):
-        parser = make_parser({})
-        config = CeleryConfig.parse(parser)
+    def test_default_heartbeat_propagates_to_dict_config(self, empty_config: ConfigParser):
+        # Arrange
+
+        # Act
+        config = CeleryConfig.parse(empty_config)
+
+        # Assert
         assert config.dict_config["broker_heartbeat"] == 120


### PR DESCRIPTION
Previously broker_heartbeat was hardcoded to 120 in CeleryConfig.dict_config. This change adds a broker_heartbeat field to CeleryConfig (default 120) that can be overridden in the celery section of config.yaml. Setting it to 0 disables the heartbeat entirely, which is useful for environments where the AMQP heartbeat causes connection drops.

Closes #25