### PR TITLE
fix: use dynamic refetchInterval to stop polling on idle projects/bat…

### DIFF
--- a/slidetap-client/src/components/project/display_project.tsx
+++ b/slidetap-client/src/components/project/display_project.tsx
@@ -122,7 +122,12 @@ export default function DisplayProject({
     queryFn: async () => {
       return await projectApi.get(projectUid)
     },
-    refetchInterval: 5000,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      return status === ProjectStatus.IN_PROGRESS || status === ProjectStatus.EXPORTING
+        ? 5000
+        : false
+    },
     placeholderData: keepPreviousData,
   })
   const datasetQuery = useQuery({
@@ -149,6 +154,16 @@ export default function DisplayProject({
       return await batchApi.get(batchUid)
     },
     enabled: batchUid != undefined,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      const activeStatuses = [
+        BatchStatus.METADATA_SEARCHING,
+        BatchStatus.IMAGE_PRE_PROCESSING,
+        BatchStatus.IMAGE_POST_PROCESSING,
+        BatchStatus.IMAGE_STORING,
+      ]
+      return status !== undefined && activeStatuses.includes(status) ? 2000 : false
+    },
     placeholderData: keepPreviousData,
   })
   useEffect(() => {

--- a/slidetap-client/src/components/project/list_projects.tsx
+++ b/slidetap-client/src/components/project/list_projects.tsx
@@ -37,7 +37,14 @@ function ListProjects(): ReactElement {
     queryFn: async () => {
       return await projectApi.getProjects()
     },
-    refetchInterval: 2000,
+    refetchInterval: (query) => {
+      const projects = query.state.data ?? []
+      return projects.some(
+        (p) => p.status === ProjectStatus.IN_PROGRESS || p.status === ProjectStatus.EXPORTING,
+      )
+        ? 2000
+        : false
+    },
     placeholderData: keepPreviousData,
   })
 


### PR DESCRIPTION
…ches

Previously projectQuery and the projects list polled unconditionally every 5s and 2s respectively, even when nothing was happening. The batchQuery had no polling at all, meaning batch status changes were only reflected on window re-focus.

Replace constant refetchInterval values with dynamic functions that only poll during active states:
- projectQuery: polls when status is IN_PROGRESS or EXPORTING
- batchQuery: polls when status is one of the active processing states
- projectsQuery: polls only when at least one project is active

image_table and item_table already used this pattern correctly; this brings the remaining components in line.