### PR TITLE
feat: add optional static frontend serving to SlideTapWebAppFactory

### DIFF
--- a/slidetap-app/src/slidetap/web/app_factory.py
+++ b/slidetap-app/src/slidetap/web/app_factory.py
@@ -24,7 +24,7 @@ from dishka.async_container import AsyncContainer
 from dishka.integrations.fastapi import setup_dishka
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from slidetap.config import CeleryConfig, SlideTapConfig
@@ -116,7 +116,11 @@ class SlideTapWebAppFactory:
         )
         setup_dishka(container=container, app=app)
         cls._create_and_register_routers(app)
-        if static_dir is not None and static_dir.exists():
+        if (
+            static_dir is not None
+            and static_dir.is_dir()
+            and (static_dir / "index.html").is_file()
+        ):
             cls._mount_spa(app, static_dir)
             logger.info(f"Serving frontend from {static_dir}.")
         logger.info("SlideTap FastAPI app created.")
@@ -133,7 +137,11 @@ class SlideTapWebAppFactory:
             app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
 
         @app.get("/{full_path:path}", include_in_schema=False)
-        def serve_spa(full_path: str) -> FileResponse:
+        def serve_spa(full_path: str):
+            if full_path.startswith("api/"):
+                return JSONResponse(
+                    status_code=404, content={"detail": "Not found"}
+                )
             return FileResponse(str(static_dir / "index.html"))
 
     @staticmethod

--- a/slidetap-app/src/slidetap/web/app_factory.py
+++ b/slidetap-app/src/slidetap/web/app_factory.py
@@ -16,6 +16,7 @@
 
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Optional
 
 from celery import Celery
@@ -23,6 +24,8 @@ from dishka.async_container import AsyncContainer
 from dishka.integrations.fastapi import setup_dishka
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from slidetap.config import CeleryConfig, SlideTapConfig
 from slidetap.services import ImageCache
@@ -51,6 +54,7 @@ class SlideTapWebAppFactory:
         cls,
         container: AsyncContainer,
         celery_app: Optional[Celery] = None,
+        static_dir: Optional[Path] = None,
     ) -> FastAPI:
         """Create a SlideTap FastAPI app using supplied implementations.
 
@@ -60,6 +64,12 @@ class SlideTapWebAppFactory:
             Dependency injection container for the application.
         celery_app : Optional[Celery]
             Optional Celery app instance. If not provided, one will be created.
+        static_dir : Optional[Path]
+            Path to a pre-built frontend dist/ directory. When provided and the
+            directory exists, the app serves the React SPA as static files so
+            that a single uvicorn process handles both the API and the frontend.
+            If the directory does not exist the parameter is silently ignored,
+            preserving the default two-server (uvicorn + Vite) workflow.
 
         Returns
         ----------
@@ -106,8 +116,25 @@ class SlideTapWebAppFactory:
         )
         setup_dishka(container=container, app=app)
         cls._create_and_register_routers(app)
+        if static_dir is not None and static_dir.exists():
+            cls._mount_spa(app, static_dir)
+            logger.info(f"Serving frontend from {static_dir}.")
         logger.info("SlideTap FastAPI app created.")
         return app
+
+    @staticmethod
+    def _mount_spa(app: FastAPI, static_dir: Path) -> None:
+        """Mount a pre-built React SPA so a single uvicorn process serves both
+        the API and the frontend.  All API routes use the /api/ prefix, so the
+        catch-all route below never shadows any endpoint.
+        """
+        assets_dir = static_dir / "assets"
+        if assets_dir.exists():
+            app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
+
+        @app.get("/{full_path:path}", include_in_schema=False)
+        def serve_spa(full_path: str) -> FileResponse:
+            return FileResponse(str(static_dir / "index.html"))
 
     @staticmethod
     def _create_and_register_routers(app: FastAPI):

--- a/slidetap-app/tests/test_app_factory_spa.py
+++ b/slidetap-app/tests/test_app_factory_spa.py
@@ -1,0 +1,88 @@
+#    Copyright 2024 SECTRA AB
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slidetap.web.app_factory import SlideTapWebAppFactory
+
+
+def _make_dist(root: Path) -> Path:
+    """Write a minimal dist/ directory matching Vite's output structure."""
+    dist = root / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html><body>SlideTap</body></html>")
+    assets = dist / "assets"
+    assets.mkdir()
+    (assets / "main.js").write_text("console.log('hello')")
+    return dist
+
+
+@pytest.mark.unittest
+class TestSlideTapWebAppFactorySpa:
+    def test_no_static_dir_does_not_mount_spa(self):
+        # When static_dir is None the factory returns a plain app with no catch-all
+        app = FastAPI()
+        SlideTapWebAppFactory._mount_spa.__doc__  # ensure method exists
+        # Verify the app has no catch-all route
+        paths = [route.path for route in app.routes]  # type: ignore[attr-defined]
+        assert "/{full_path:path}" not in paths
+
+    def test_missing_static_dir_is_silently_ignored(self):
+        # Passing a non-existent path must not raise
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "nonexistent_dist"
+            app = FastAPI()
+            # _mount_spa is only called if the dir exists; caller guards with .exists()
+            assert not missing.exists()
+            # No exception raised; nothing mounted
+            paths = [route.path for route in app.routes]  # type: ignore[attr-defined]
+            assert "/{full_path:path}" not in paths
+
+    def test_existing_static_dir_mounts_assets_and_spa_route(self):
+        with TemporaryDirectory() as tmp:
+            dist = _make_dist(Path(tmp))
+            app = FastAPI()
+            SlideTapWebAppFactory._mount_spa(app, dist)
+            paths = [route.path for route in app.routes]  # type: ignore[attr-defined]
+            assert "/{full_path:path}" in paths
+            mount_names = [
+                r.name  # type: ignore[attr-defined]
+                for r in app.routes
+                if hasattr(r, "name") and r.name == "assets"
+            ]
+            assert mount_names, "assets mount not found"
+
+    def test_spa_route_serves_index_html(self):
+        with TemporaryDirectory() as tmp:
+            dist = _make_dist(Path(tmp))
+            app = FastAPI()
+            SlideTapWebAppFactory._mount_spa(app, dist)
+            client = TestClient(app, raise_server_exceptions=True)
+            response = client.get("/some/frontend/route")
+            assert response.status_code == 200
+            assert b"SlideTap" in response.content
+
+    def test_assets_are_served(self):
+        with TemporaryDirectory() as tmp:
+            dist = _make_dist(Path(tmp))
+            app = FastAPI()
+            SlideTapWebAppFactory._mount_spa(app, dist)
+            client = TestClient(app)
+            response = client.get("/assets/main.js")
+            assert response.status_code == 200
+            assert b"hello" in response.content

--- a/slidetap-app/tests/test_app_factory_spa.py
+++ b/slidetap-app/tests/test_app_factory_spa.py
@@ -14,6 +14,7 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -21,68 +22,147 @@ from fastapi.testclient import TestClient
 from slidetap.web.app_factory import SlideTapWebAppFactory
 
 
-def _make_dist(root: Path) -> Path:
-    """Write a minimal dist/ directory matching Vite's output structure."""
-    dist = root / "dist"
-    dist.mkdir()
-    (dist / "index.html").write_text("<html><body>SlideTap</body></html>")
-    assets = dist / "assets"
-    assets.mkdir()
-    (assets / "main.js").write_text("console.log('hello')")
-    return dist
+@pytest.fixture()
+def dist_dir():
+    """Create minimal Vite-style dist/ with index.html and assets/main.js."""
+    with TemporaryDirectory() as tmp:
+        dist = Path(tmp) / "dist"
+        dist.mkdir()
+        (dist / "index.html").write_text("<html><body>SlideTap</body></html>")
+        assets = dist / "assets"
+        assets.mkdir()
+        (assets / "main.js").write_text("console.log('hello')")
+        yield dist
+
+
+@pytest.fixture()
+def spa_app(dist_dir: Path):
+    """FastAPI app with SPA mounted."""
+    app = FastAPI()
+    SlideTapWebAppFactory._mount_spa(app, dist_dir)
+    return app
+
+
+@pytest.fixture()
+def spa_client(spa_app: FastAPI):
+    return TestClient(spa_app, raise_server_exceptions=True)
 
 
 @pytest.mark.unittest
-class TestSlideTapWebAppFactorySpa:
-    def test_no_static_dir_does_not_mount_spa(self):
-        # When static_dir is None the factory returns a plain app with no catch-all
-        app = FastAPI()
-        SlideTapWebAppFactory._mount_spa.__doc__  # ensure method exists
-        # Verify the app has no catch-all route
-        paths = [route.path for route in app.routes]  # type: ignore[attr-defined]
-        assert "/{full_path:path}" not in paths
+class TestMountSpa:
+    def test_mounts_catch_all_route(self, spa_app: FastAPI):
+        # Arrange
 
-    def test_missing_static_dir_is_silently_ignored(self):
-        # Passing a non-existent path must not raise
-        with TemporaryDirectory() as tmp:
-            missing = Path(tmp) / "nonexistent_dist"
-            app = FastAPI()
-            # _mount_spa is only called if the dir exists; caller guards with .exists()
-            assert not missing.exists()
-            # No exception raised; nothing mounted
-            paths = [route.path for route in app.routes]  # type: ignore[attr-defined]
-            assert "/{full_path:path}" not in paths
+        # Act
+        paths = [route.path for route in spa_app.routes]  # type: ignore[attr-defined]
 
-    def test_existing_static_dir_mounts_assets_and_spa_route(self):
+        # Assert
+        assert "/{full_path:path}" in paths
+
+    def test_mounts_assets_directory(self, spa_app: FastAPI):
+        # Arrange
+
+        # Act
+        mount_names = [
+            r.name  # type: ignore[attr-defined]
+            for r in spa_app.routes
+            if hasattr(r, "name") and r.name == "assets"
+        ]
+
+        # Assert
+        assert mount_names, "assets mount not found"
+
+    def test_serves_index_html_for_frontend_routes(self, spa_client: TestClient):
+        # Arrange
+
+        # Act
+        response = spa_client.get("/some/frontend/route")
+
+        # Assert
+        assert response.status_code == 200
+        assert b"SlideTap" in response.content
+
+    def test_serves_assets(self, spa_client: TestClient):
+        # Arrange
+
+        # Act
+        response = spa_client.get("/assets/main.js")
+
+        # Assert
+        assert response.status_code == 200
+        assert b"hello" in response.content
+
+    def test_api_paths_return_404(self, spa_client: TestClient):
+        # Arrange
+
+        # Act
+        response = spa_client.get("/api/does-not-exist")
+
+        # Assert
+        assert response.status_code == 404
+
+    def test_skips_assets_mount_when_no_assets_dir(self):
+        # Arrange
         with TemporaryDirectory() as tmp:
-            dist = _make_dist(Path(tmp))
+            dist = Path(tmp) / "dist"
+            dist.mkdir()
+            (dist / "index.html").write_text("<html></html>")
             app = FastAPI()
+
+            # Act
             SlideTapWebAppFactory._mount_spa(app, dist)
-            paths = [route.path for route in app.routes]  # type: ignore[attr-defined]
-            assert "/{full_path:path}" in paths
             mount_names = [
                 r.name  # type: ignore[attr-defined]
                 for r in app.routes
                 if hasattr(r, "name") and r.name == "assets"
             ]
-            assert mount_names, "assets mount not found"
 
-    def test_spa_route_serves_index_html(self):
-        with TemporaryDirectory() as tmp:
-            dist = _make_dist(Path(tmp))
-            app = FastAPI()
-            SlideTapWebAppFactory._mount_spa(app, dist)
-            client = TestClient(app, raise_server_exceptions=True)
-            response = client.get("/some/frontend/route")
-            assert response.status_code == 200
-            assert b"SlideTap" in response.content
+            # Assert
+            assert not mount_names
 
-    def test_assets_are_served(self):
+
+@pytest.mark.unittest
+class TestCreateStaticDirGuard:
+    def test_no_static_dir_does_not_mount(self):
+        # Arrange
+
+        # Act / Assert — _mount_spa should not be called when static_dir is None
+        with patch.object(SlideTapWebAppFactory, "_mount_spa") as mock:
+            # Simulate factory guard: static_dir is None
+            static_dir = None
+            if (
+                static_dir is not None
+                and static_dir.is_dir()
+                and (static_dir / "index.html").is_file()
+            ):
+                SlideTapWebAppFactory._mount_spa(FastAPI(), static_dir)
+            mock.assert_not_called()
+
+    def test_missing_dir_does_not_mount(self):
+        # Arrange
         with TemporaryDirectory() as tmp:
-            dist = _make_dist(Path(tmp))
-            app = FastAPI()
-            SlideTapWebAppFactory._mount_spa(app, dist)
-            client = TestClient(app)
-            response = client.get("/assets/main.js")
-            assert response.status_code == 200
-            assert b"hello" in response.content
+            missing = Path(tmp) / "nonexistent"
+
+            # Act / Assert
+            with patch.object(SlideTapWebAppFactory, "_mount_spa") as mock:
+                if (
+                    missing.is_dir()
+                    and (missing / "index.html").is_file()
+                ):
+                    SlideTapWebAppFactory._mount_spa(FastAPI(), missing)
+                mock.assert_not_called()
+
+    def test_dir_without_index_html_does_not_mount(self):
+        # Arrange
+        with TemporaryDirectory() as tmp:
+            empty_dir = Path(tmp) / "dist"
+            empty_dir.mkdir()
+
+            # Act / Assert
+            with patch.object(SlideTapWebAppFactory, "_mount_spa") as mock:
+                if (
+                    empty_dir.is_dir()
+                    and (empty_dir / "index.html").is_file()
+                ):
+                    SlideTapWebAppFactory._mount_spa(FastAPI(), empty_dir)
+                mock.assert_not_called()


### PR DESCRIPTION
Add an optional static_dir parameter to SlideTapWebAppFactory.create(). When a pre-built dist/ directory is provided and exists, the factory mounts the assets/ subdirectory and adds a catch-all SPA route that serves index.html for all non-API paths.

This allows developers to run 'npm run build' once and then serve both the API and frontend from a single uvicorn process, reducing the local dev workflow from three terminals to two. When static_dir is None or the directory does not exist the behaviour is unchanged.

Production Docker/Nginx deployments are unaffected. All API routes use the /api/ prefix so the catch-all route never conflicts with any endpoint.