### PR TITLE
Stop _open_wsidicomizer from swallowing with-body exceptions

### DIFF
--- a/slidetap-app/src/slidetap/image_processor/image_processing_step.py
+++ b/slidetap-app/src/slidetap/image_processor/image_processing_step.py
@@ -137,9 +137,7 @@ class ImageProcessingStep(metaclass=ABCMeta):
             except Exception as exception:
                 self._logger.error(exception, exc_info=True)
                 continue
-            self._logger.debug(
-                f"Found file {image_path} for image {image.identifier}."
-            )
+            self._logger.debug(f"Found file {image_path} for image {image.identifier}.")
             try:
                 yield wsi
             finally:

--- a/slidetap-app/src/slidetap/image_processor/image_processing_step.py
+++ b/slidetap-app/src/slidetap/image_processor/image_processing_step.py
@@ -123,33 +123,39 @@ class ImageProcessingStep(metaclass=ABCMeta):
     ):
         if len(image.files) == 0:
             self._logger.error(f"No image files for image {image.identifier}")
-            yield
+            yield None
             return
         for file in image.files:
             image_path = path.joinpath(file.filename)
+            self._logger.debug(
+                f"Testing file {image_path} for image {image.identifier}."
+            )
             try:
-                self._logger.debug(
-                    f"Testing file {image_path} for image {image.identifier}."
-                )
                 wsi = WsiDicomizer.open(
                     image_path, include_confidential=False, metadata=metadata, **kwargs
                 )
-                self._logger.debug(
-                    f"Found file {image_path} for image {image.identifier}."
-                )
-                try:
-                    yield wsi
-                finally:
-                    wsi.close()
             except Exception as exception:
                 self._logger.error(exception, exc_info=True)
-                pass
+                continue
+            self._logger.debug(
+                f"Found file {image_path} for image {image.identifier}."
+            )
+            try:
+                yield wsi
+            finally:
+                try:
+                    wsi.close()
+                except Exception:
+                    self._logger.exception(
+                        f"Error closing wsi for image {image.identifier}"
+                    )
+            return
 
         self._logger.error(
             f"No supported image file found for image {image.identifier} "
             f"in {image.folder_path}."
         )
-        yield
+        yield None
 
     @contextmanager
     def _open_wsidicom(

--- a/slidetap-app/src/slidetap/image_processor/image_processing_step.py
+++ b/slidetap-app/src/slidetap/image_processor/image_processing_step.py
@@ -161,12 +161,21 @@ class ImageProcessingStep(metaclass=ABCMeta):
     ) -> Generator[WsiDicom | None, Any, None]:
         try:
             wsi = WsiDicom.open(path, **kwargs)
-            try:
-                yield wsi
-            finally:
-                wsi.close()
         except Exception:
+            self._logger.error(
+                f"Failed to open WsiDicom for image {image.identifier}", exc_info=True
+            )
             yield None
+            return
+        try:
+            yield wsi
+        finally:
+            try:
+                wsi.close()
+            except Exception:
+                self._logger.exception(
+                    f"Error closing wsi for image {image.identifier}"
+                )
 
 
 class StoreProcessingStep(ImageProcessingStep):

--- a/slidetap-app/tests/test_image_processing_step.py
+++ b/slidetap-app/tests/test_image_processing_step.py
@@ -1,0 +1,126 @@
+#    Copyright 2024 SECTRA AB
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from slidetap.image_processor.image_processing_step import ImageProcessingStep
+from slidetap.model import Image, ImageFile, ImageFormat
+
+
+class _NoopStep(ImageProcessingStep):
+    def run(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def image() -> Image:
+    return Image(
+        uid=uuid4(),
+        identifier="img-1",
+        dataset_uid=uuid4(),
+        schema_uid=uuid4(),
+        format=ImageFormat.OTHER_WSI,
+        files=[ImageFile(uid=uuid4(), filename="CMU-1.vms")],
+    )
+
+
+@pytest.fixture
+def step() -> ImageProcessingStep:
+    return _NoopStep()
+
+
+def test_open_wsidicomizer_propagates_body_exception(
+    step: ImageProcessingStep, image: Image
+) -> None:
+    """Regression test for imi-bigpicture/slidetap#40.
+
+    An exception raised inside the consumer's ``with _open_wsidicomizer(...)``
+    block must propagate to the caller. Previously the surrounding
+    ``try/except Exception/pass`` swallowed it silently, masking pre-process
+    failures (e.g. imi-bigpicture/bigpicture-slidetap#20)."""
+    wsi = MagicMock()
+    with patch(
+        "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+        return_value=wsi,
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            with step._open_wsidicomizer(image, Path("/tmp")) as opened:
+                assert opened is wsi
+                raise RuntimeError("boom")
+
+    wsi.close.assert_called_once()
+
+
+def test_open_wsidicomizer_skips_failed_open_and_uses_next_file(
+    step: ImageProcessingStep,
+) -> None:
+    """A failure opening file N must not prevent file N+1 from being tried."""
+    image = Image(
+        uid=uuid4(),
+        identifier="img-2",
+        dataset_uid=uuid4(),
+        schema_uid=uuid4(),
+        format=ImageFormat.OTHER_WSI,
+        files=[
+            ImageFile(uid=uuid4(), filename="broken.vms"),
+            ImageFile(uid=uuid4(), filename="good.vms"),
+        ],
+    )
+    good_wsi = MagicMock()
+
+    def _open(image_path, **kwargs):
+        if image_path.name == "broken.vms":
+            raise OSError("cannot read")
+        return good_wsi
+
+    with patch(
+        "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+        side_effect=_open,
+    ):
+        with step._open_wsidicomizer(image, Path("/tmp")) as opened:
+            assert opened is good_wsi
+
+    good_wsi.close.assert_called_once()
+
+
+def test_open_wsidicomizer_yields_none_when_no_file_opens(
+    step: ImageProcessingStep, image: Image
+) -> None:
+    """When no file successfully opens, the contextmanager must yield ``None``
+    (downstream callers check ``if wsi is None``)."""
+    with patch(
+        "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+        side_effect=OSError("cannot read"),
+    ):
+        with step._open_wsidicomizer(image, Path("/tmp")) as opened:
+            assert opened is None
+
+
+def test_open_wsidicomizer_yields_none_when_image_has_no_files(
+    step: ImageProcessingStep,
+) -> None:
+    image = Image(
+        uid=uuid4(),
+        identifier="img-empty",
+        dataset_uid=uuid4(),
+        schema_uid=uuid4(),
+        format=ImageFormat.OTHER_WSI,
+        files=[],
+    )
+    with step._open_wsidicomizer(image, Path("/tmp")) as opened:
+        assert opened is None

--- a/slidetap-app/tests/test_image_processing_step.py
+++ b/slidetap-app/tests/test_image_processing_step.py
@@ -45,7 +45,7 @@ def step() -> ImageProcessingStep:
 
 
 def test_open_wsidicomizer_propagates_body_exception(
-    step: ImageProcessingStep, image: Image
+    step: ImageProcessingStep, image: Image, tmp_path: Path
 ) -> None:
     """Regression test for imi-bigpicture/slidetap#40.
 
@@ -54,20 +54,22 @@ def test_open_wsidicomizer_propagates_body_exception(
     ``try/except Exception/pass`` swallowed it silently, masking pre-process
     failures (e.g. imi-bigpicture/bigpicture-slidetap#20)."""
     wsi = MagicMock()
-    with patch(
-        "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
-        return_value=wsi,
+    with (
+        patch(
+            "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+            return_value=wsi,
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+        step._open_wsidicomizer(image, tmp_path) as opened,
     ):
-        with pytest.raises(RuntimeError, match="boom"):
-            with step._open_wsidicomizer(image, Path("/tmp")) as opened:
-                assert opened is wsi
-                raise RuntimeError("boom")
+        assert opened is wsi
+        raise RuntimeError("boom")
 
     wsi.close.assert_called_once()
 
 
 def test_open_wsidicomizer_skips_failed_open_and_uses_next_file(
-    step: ImageProcessingStep,
+    step: ImageProcessingStep, tmp_path: Path
 ) -> None:
     """A failure opening file N must not prevent file N+1 from being tried."""
     image = Image(
@@ -88,31 +90,35 @@ def test_open_wsidicomizer_skips_failed_open_and_uses_next_file(
             raise OSError("cannot read")
         return good_wsi
 
-    with patch(
-        "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
-        side_effect=_open,
+    with (
+        patch(
+            "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+            side_effect=_open,
+        ),
+        step._open_wsidicomizer(image, tmp_path) as opened,
     ):
-        with step._open_wsidicomizer(image, Path("/tmp")) as opened:
-            assert opened is good_wsi
+        assert opened is good_wsi
 
     good_wsi.close.assert_called_once()
 
 
 def test_open_wsidicomizer_yields_none_when_no_file_opens(
-    step: ImageProcessingStep, image: Image
+    step: ImageProcessingStep, image: Image, tmp_path: Path
 ) -> None:
     """When no file successfully opens, the contextmanager must yield ``None``
     (downstream callers check ``if wsi is None``)."""
-    with patch(
-        "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
-        side_effect=OSError("cannot read"),
+    with (
+        patch(
+            "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+            side_effect=OSError("cannot read"),
+        ),
+        step._open_wsidicomizer(image, tmp_path) as opened,
     ):
-        with step._open_wsidicomizer(image, Path("/tmp")) as opened:
-            assert opened is None
+        assert opened is None
 
 
 def test_open_wsidicomizer_yields_none_when_image_has_no_files(
-    step: ImageProcessingStep,
+    step: ImageProcessingStep, tmp_path: Path
 ) -> None:
     image = Image(
         uid=uuid4(),
@@ -122,5 +128,5 @@ def test_open_wsidicomizer_yields_none_when_image_has_no_files(
         format=ImageFormat.OTHER_WSI,
         files=[],
     )
-    with step._open_wsidicomizer(image, Path("/tmp")) as opened:
+    with step._open_wsidicomizer(image, tmp_path) as opened:
         assert opened is None

--- a/slidetap-app/tests/test_image_processing_step.py
+++ b/slidetap-app/tests/test_image_processing_step.py
@@ -13,10 +13,12 @@
 #    limitations under the License.
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from decoy import Decoy
+from wsidicomizer import WsiDicomizer
 
 from slidetap.image_processor.image_processing_step import ImageProcessingStep
 from slidetap.model import Image, ImageFile, ImageFormat
@@ -27,106 +29,114 @@ class _NoopStep(ImageProcessingStep):
         raise NotImplementedError
 
 
-@pytest.fixture
-def image() -> Image:
-    return Image(
-        uid=uuid4(),
-        identifier="img-1",
-        dataset_uid=uuid4(),
-        schema_uid=uuid4(),
-        format=ImageFormat.OTHER_WSI,
-        files=[ImageFile(uid=uuid4(), filename="CMU-1.vms")],
-    )
+@pytest.mark.unittest
+class TestOpenWsidicomizer:
+    @pytest.fixture
+    def image(self) -> Image:
+        return Image(
+            uid=uuid4(),
+            identifier="img-1",
+            dataset_uid=uuid4(),
+            schema_uid=uuid4(),
+            format=ImageFormat.OTHER_WSI,
+            files=[ImageFile(uid=uuid4(), filename="CMU-1.vms")],
+        )
 
+    @pytest.fixture
+    def step(self) -> ImageProcessingStep:
+        return _NoopStep()
 
-@pytest.fixture
-def step() -> ImageProcessingStep:
-    return _NoopStep()
+    def test_open_wsidicomizer_propagates_body_exception(
+        self, decoy: Decoy, step: ImageProcessingStep, image: Image, tmp_path: Path
+    ) -> None:
+        """Regression test for imi-bigpicture/slidetap#40.
 
+        An exception raised inside the consumer's ``with _open_wsidicomizer(...)``
+        block must propagate to the caller. Previously the surrounding
+        ``try/except Exception/pass`` swallowed it silently, masking pre-process
+        failures (e.g. imi-bigpicture/bigpicture-slidetap#20)."""
+        # Arrange
+        wsi = decoy.mock(cls=WsiDicomizer)
 
-def test_open_wsidicomizer_propagates_body_exception(
-    step: ImageProcessingStep, image: Image, tmp_path: Path
-) -> None:
-    """Regression test for imi-bigpicture/slidetap#40.
+        # Act / Assert
+        with (
+            patch(
+                "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+                return_value=wsi,
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+            step._open_wsidicomizer(image, tmp_path) as opened,
+        ):
+            assert opened is wsi
+            raise RuntimeError("boom")
 
-    An exception raised inside the consumer's ``with _open_wsidicomizer(...)``
-    block must propagate to the caller. Previously the surrounding
-    ``try/except Exception/pass`` swallowed it silently, masking pre-process
-    failures (e.g. imi-bigpicture/bigpicture-slidetap#20)."""
-    wsi = MagicMock()
-    with (
-        patch(
-            "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
-            return_value=wsi,
-        ),
-        pytest.raises(RuntimeError, match="boom"),
-        step._open_wsidicomizer(image, tmp_path) as opened,
-    ):
-        assert opened is wsi
-        raise RuntimeError("boom")
+        decoy.verify(wsi.close(), times=1)
 
-    wsi.close.assert_called_once()
+    def test_open_wsidicomizer_skips_failed_open_and_uses_next_file(
+        self, decoy: Decoy, step: ImageProcessingStep, tmp_path: Path
+    ) -> None:
+        """A failure opening file N must not prevent file N+1 from being tried."""
+        # Arrange
+        image = Image(
+            uid=uuid4(),
+            identifier="img-2",
+            dataset_uid=uuid4(),
+            schema_uid=uuid4(),
+            format=ImageFormat.OTHER_WSI,
+            files=[
+                ImageFile(uid=uuid4(), filename="broken.vms"),
+                ImageFile(uid=uuid4(), filename="good.vms"),
+            ],
+        )
+        good_wsi = decoy.mock(cls=WsiDicomizer)
 
+        def _open(image_path, **kwargs):
+            if image_path.name == "broken.vms":
+                raise OSError("cannot read")
+            return good_wsi
 
-def test_open_wsidicomizer_skips_failed_open_and_uses_next_file(
-    step: ImageProcessingStep, tmp_path: Path
-) -> None:
-    """A failure opening file N must not prevent file N+1 from being tried."""
-    image = Image(
-        uid=uuid4(),
-        identifier="img-2",
-        dataset_uid=uuid4(),
-        schema_uid=uuid4(),
-        format=ImageFormat.OTHER_WSI,
-        files=[
-            ImageFile(uid=uuid4(), filename="broken.vms"),
-            ImageFile(uid=uuid4(), filename="good.vms"),
-        ],
-    )
-    good_wsi = MagicMock()
+        # Act / Assert
+        with (
+            patch(
+                "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+                side_effect=_open,
+            ),
+            step._open_wsidicomizer(image, tmp_path) as opened,
+        ):
+            assert opened is good_wsi
 
-    def _open(image_path, **kwargs):
-        if image_path.name == "broken.vms":
-            raise OSError("cannot read")
-        return good_wsi
+        decoy.verify(good_wsi.close(), times=1)
 
-    with (
-        patch(
-            "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
-            side_effect=_open,
-        ),
-        step._open_wsidicomizer(image, tmp_path) as opened,
-    ):
-        assert opened is good_wsi
+    def test_open_wsidicomizer_yields_none_when_no_file_opens(
+        self, step: ImageProcessingStep, image: Image, tmp_path: Path
+    ) -> None:
+        """When no file successfully opens, the contextmanager must yield ``None``
+        (downstream callers check ``if wsi is None``)."""
+        # Arrange
 
-    good_wsi.close.assert_called_once()
+        # Act / Assert
+        with (
+            patch(
+                "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
+                side_effect=OSError("cannot read"),
+            ),
+            step._open_wsidicomizer(image, tmp_path) as opened,
+        ):
+            assert opened is None
 
+    def test_open_wsidicomizer_yields_none_when_image_has_no_files(
+        self, step: ImageProcessingStep, tmp_path: Path
+    ) -> None:
+        # Arrange
+        image = Image(
+            uid=uuid4(),
+            identifier="img-empty",
+            dataset_uid=uuid4(),
+            schema_uid=uuid4(),
+            format=ImageFormat.OTHER_WSI,
+            files=[],
+        )
 
-def test_open_wsidicomizer_yields_none_when_no_file_opens(
-    step: ImageProcessingStep, image: Image, tmp_path: Path
-) -> None:
-    """When no file successfully opens, the contextmanager must yield ``None``
-    (downstream callers check ``if wsi is None``)."""
-    with (
-        patch(
-            "slidetap.image_processor.image_processing_step.WsiDicomizer.open",
-            side_effect=OSError("cannot read"),
-        ),
-        step._open_wsidicomizer(image, tmp_path) as opened,
-    ):
-        assert opened is None
-
-
-def test_open_wsidicomizer_yields_none_when_image_has_no_files(
-    step: ImageProcessingStep, tmp_path: Path
-) -> None:
-    image = Image(
-        uid=uuid4(),
-        identifier="img-empty",
-        dataset_uid=uuid4(),
-        schema_uid=uuid4(),
-        format=ImageFormat.OTHER_WSI,
-        files=[],
-    )
-    with step._open_wsidicomizer(image, tmp_path) as opened:
-        assert opened is None
+        # Act / Assert
+        with step._open_wsidicomizer(image, tmp_path) as opened:
+            assert opened is None


### PR DESCRIPTION
## Summary

Fixes #40. `ImageProcessingStep._open_wsidicomizer` previously wrapped the entire per-file body (including `yield wsi`) in `try/except Exception/pass`, silently swallowing any exception raised inside the consumer's `with`-block. Pre-process steps that failed mid-flow — e.g. `bigpicture-slidetap.GetMetadata.run` hitting `AttributeError` on a missing pydicom tag (imi-bigpicture/bigpicture-slidetap#20) — appeared to succeed, leaving images at `status=PRE_PROCESSED` with empty attributes and no log trace.

### Changes
- `try/except` now wraps only `WsiDicomizer.open` itself; open failures log and `continue` to the next file (unchanged contract).
- `yield wsi` lives in its own `try/finally` whose only job is to close the wsi. `wsi.close()` exceptions are caught locally so they cannot mask body exceptions.
- A `return` after the successful yield's finally block ensures the contextmanager yields exactly once on success (previously the loop continued and yielded again, violating the `@contextmanager` contract).
- Error paths now `yield None` explicitly (downstream callers check `if wsi is None`).

Adds `tests/test_image_processing_step.py` with four regression tests:

- `test_open_wsidicomizer_propagates_body_exception` — the actual issue #40 acceptance test.
- `test_open_wsidicomizer_skips_failed_open_and_uses_next_file` — preserves per-file fallback behaviour.
- `test_open_wsidicomizer_yields_none_when_no_file_opens` — `None`-yield contract.
- `test_open_wsidicomizer_yields_none_when_image_has_no_files` — `None`-yield contract.

All four pass locally against the fixed code.

## Test plan

- [x] New regression tests pass (`uv run pytest tests/test_image_processing_step.py -v` → 4 passed).
- [ ] Existing test suite passes (CI).
- [ ] Integration sanity: an injected mid-pre-process exception now ends with `image.status=PRE_PROCESSING_FAILED` in the DB and a traceback in `docker compose logs slidetap-task` (verified downstream in bp-submission-pipeline after pin bump).

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)