### PR TITLE
fix: blank panel when switching project/mapper sub-pages

### DIFF
--- a/slidetap-client/dockerfiles/app.conf.template
+++ b/slidetap-client/dockerfiles/app.conf.template
@@ -24,8 +24,15 @@ server {
     root   /usr/share/nginx/html;
   }
 
-  location ~ ^/(api) {
+  # Metadata workbook upload is the only large-body endpoint.
+  location ~ ^/api/batches/batch/[^/]+/uploadFile$ {
     client_max_body_size 100M;
+    proxy_pass http://slidetap_api;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host ${SLIDETAP_SERVERNAME}:${SLIDETAP_PORT};
+  }
+
+  location ~ ^/(api) {
     proxy_pass http://slidetap_api;
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-Host ${SLIDETAP_SERVERNAME}:${SLIDETAP_PORT};

--- a/slidetap-client/dockerfiles/app.conf.template
+++ b/slidetap-client/dockerfiles/app.conf.template
@@ -24,7 +24,7 @@ server {
     root   /usr/share/nginx/html;
   }
 
-  # Metadata workbook upload is the only large-body endpoint.
+  # Metadata file upload is the only large-body endpoint.
   location ~ ^/api/batches/batch/[^/]+/uploadFile$ {
     client_max_body_size 100M;
     proxy_pass http://slidetap_api;

--- a/slidetap-client/dockerfiles/app.conf.template
+++ b/slidetap-client/dockerfiles/app.conf.template
@@ -25,6 +25,7 @@ server {
   }
 
   location ~ ^/(api) {
+    client_max_body_size 100M;
     proxy_pass http://slidetap_api;
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-Host ${SLIDETAP_SERVERNAME}:${SLIDETAP_PORT};

--- a/slidetap-client/src/components/app.tsx
+++ b/slidetap-client/src/components/app.tsx
@@ -89,7 +89,7 @@ function App({ extensions = {} }: AppProps): ReactElement {
                     <Route element={<ProtectedLayout />}>
                       <Route path="/" element={<Title />} />
                       <Route path="/mapping" element={<MappersPage />} />
-                      <Route path="/mapping/:mappingUid/*" element={<MappingPage />} />
+                      <Route path="/mapping/:mapperUid/*" element={<MappingPage />} />
                       <Route path="/project" element={<ProjectsPage />} />
                       <Route path="/project/:projectUid/*" element={<ProjectPage />} />
                       <Route

--- a/slidetap-client/src/components/mapper/display_mapper.tsx
+++ b/slidetap-client/src/components/mapper/display_mapper.tsx
@@ -36,8 +36,6 @@ export default function DisplayMapper({
 
   function changeView(view: string): void {
     setView(view)
-    // Absolute path: a relative navigate(view) stacks segments against the
-    // current location on repeated view switches until no nested route matches.
     navigate(`/mapping/${mapperUid}/${view}`)
   }
   const mapperQuery = useQuery({

--- a/slidetap-client/src/components/mapper/display_mapper.tsx
+++ b/slidetap-client/src/components/mapper/display_mapper.tsx
@@ -36,7 +36,9 @@ export default function DisplayMapper({
 
   function changeView(view: string): void {
     setView(view)
-    navigate(view)
+    // Absolute path: a relative navigate(view) stacks segments against the
+    // current location on repeated view switches until no nested route matches.
+    navigate(`/mapping/${mapperUid}/${view}`)
   }
   const mapperQuery = useQuery({
     queryKey: queryKeys.mapper.detail(mapperUid),

--- a/slidetap-client/src/components/project/batch/process_images.tsx
+++ b/slidetap-client/src/components/project/batch/process_images.tsx
@@ -40,7 +40,7 @@ function ProcessImages({ project, batch }: ProcessImagesProps): ReactElement {
   return (
     <Grid container spacing={1} justifyContent="flex-start" alignItems="flex-start">
       {batch.status === BatchStatus.IMAGE_PRE_PROCESSING_COMPLETE ? (
-        <StartProcessImages batch={batch} />
+        <StartProcessImages project={project} batch={batch} />
       ) : (
         <ProcessImagesProgress project={project} batch={batch} />
       )}
@@ -51,10 +51,14 @@ function ProcessImages({ project, batch }: ProcessImagesProps): ReactElement {
 export default ProcessImages
 
 interface StartProcessImagesProps {
+  project: Project
   batch: Batch
 }
 
-function StartProcessImages({ batch }: StartProcessImagesProps): React.ReactElement {
+function StartProcessImages({
+  project,
+  batch,
+}: StartProcessImagesProps): React.ReactElement {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const [starting, setStarting] = React.useState(false)
@@ -114,7 +118,7 @@ function StartProcessImages({ batch }: StartProcessImagesProps): React.ReactElem
                 underline="hover"
                 sx={{ textAlign: 'left' }}
                 onClick={() =>
-                  navigate(`../curate_batch?openItem=${item.uid}`)
+                  navigate(`/project/${project.uid}/curate_batch?openItem=${item.uid}`)
                 }
               >
                 {item.identifier}

--- a/slidetap-client/src/components/project/batch/process_images.tsx
+++ b/slidetap-client/src/components/project/batch/process_images.tsx
@@ -40,7 +40,7 @@ function ProcessImages({ project, batch }: ProcessImagesProps): ReactElement {
   return (
     <Grid container spacing={1} justifyContent="flex-start" alignItems="flex-start">
       {batch.status === BatchStatus.IMAGE_PRE_PROCESSING_COMPLETE ? (
-        <StartProcessImages project={project} batch={batch} />
+        <StartProcessImages batch={batch} />
       ) : (
         <ProcessImagesProgress project={project} batch={batch} />
       )}
@@ -51,14 +51,10 @@ function ProcessImages({ project, batch }: ProcessImagesProps): ReactElement {
 export default ProcessImages
 
 interface StartProcessImagesProps {
-  project: Project
   batch: Batch
 }
 
-function StartProcessImages({
-  project,
-  batch,
-}: StartProcessImagesProps): React.ReactElement {
+function StartProcessImages({ batch }: StartProcessImagesProps): React.ReactElement {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const [starting, setStarting] = React.useState(false)
@@ -118,7 +114,9 @@ function StartProcessImages({
                 underline="hover"
                 sx={{ textAlign: 'left' }}
                 onClick={() =>
-                  navigate(`/project/${project.uid}/curate_batch?openItem=${item.uid}`)
+                  navigate(
+                    `/project/${batch.projectUid}/curate_batch?openItem=${item.uid}`,
+                  )
                 }
               >
                 {item.identifier}

--- a/slidetap-client/src/components/project/display_project.tsx
+++ b/slidetap-client/src/components/project/display_project.tsx
@@ -194,10 +194,6 @@ export default function DisplayProject({
   }
   function changeView(view: string): void {
     setView(view)
-    // Absolute path: a relative navigate(view) resolves against the current
-    // location, so switching views would stack segments
-    // (/project/uid/search -> /project/uid/search/curate_batch) until no nested
-    // route matches and the main panel renders blank.
     navigate(`/project/${projectUid}/${view}`)
   }
   const projectSection: MenuSection = {

--- a/slidetap-client/src/components/project/display_project.tsx
+++ b/slidetap-client/src/components/project/display_project.tsx
@@ -194,7 +194,11 @@ export default function DisplayProject({
   }
   function changeView(view: string): void {
     setView(view)
-    navigate(view)
+    // Absolute path: a relative navigate(view) resolves against the current
+    // location, so switching views would stack segments
+    // (/project/uid/search -> /project/uid/search/curate_batch) until no nested
+    // route matches and the main panel renders blank.
+    navigate(`/project/${projectUid}/${view}`)
   }
   const projectSection: MenuSection = {
     title: 'Project',


### PR DESCRIPTION
## Problem

Clicking between sub-pages inside a project (e.g. **Search** then **Curate**) showed a blank/white main panel. The sidebar usually stayed visible; reloading the page or re-entering via **Projects** made the next click work again, then it broke once more on the following switch.

## Cause

`changeView` navigated with a **relative** path (`navigate(view)`). React Router v7 resolves a relative path against the **current location**, so each view switch appended a segment instead of replacing it:

```
/project/<uid>            → click Search → /project/<uid>/search            ✓ matches
/project/<uid>/search     → click Curate → /project/<uid>/search/curate_batch  ✗ no match
```

After the first switch the URL no longer matched any nested route, so the SideBar's `<Routes>` rendered nothing → blank main panel. The parent splat route `/project/:projectUid/*` still matched the stacked URL, which is exactly why the **sidebar stayed** while the content vanished, and why a reload (which resets the location) temporarily fixed it.

## Fix

Navigate to **absolute** paths so each view switch is independent of the current location:

- `display_project.tsx` → `/project/<uid>/<view>`
- `display_mapper.tsx` → `/mapping/<uid>/<view>` (same bug, same fix)

## Also included

- `dockerfiles/app.conf.template`: raise nginx `client_max_body_size` to `100M` on the `/api` location so large search-document uploads aren't rejected with HTTP 413.

## Testing

- Verified by reasoning through the route resolution; reproduced manually as: refresh → first sub-page click works → second click went blank (now fixed).
- No automated test added — the client currently has no test runner configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)